### PR TITLE
New Feature : Download the Allen template

### DIFF
--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -6,6 +6,7 @@ Scripts
 
     scripts/m2m_compute_transform_matrix
     scripts/m2m_crossing_finder
+    scripts/m2m_download_template
     scripts/m2m_tract_filter
     scripts/m2m_import_proj_density
     scripts/m2m_import_tract

--- a/docs/scripts/m2m_download_template.rst
+++ b/docs/scripts/m2m_download_template.rst
@@ -1,0 +1,8 @@
+.. _script-m2m-download-template:
+
+m2m_download_template
+=====================
+.. argparse::
+   :filename: ../scripts/m2m_download_template.py
+   :func: _build_arg_parser
+   :prog: m2m_download_template.py

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -57,12 +57,30 @@ If none of this work, try installing the dependencies with an anaconda virtual e
 
 Uses cases
 ----------
+Python
+~~~~~~
+
+* Display the help for a script
+.. code-block:: bash
+
+    python scripts/m2m_compute_transform_matrix.py --help
+
+* Download an Allen mouse brain template at 25 micron, and reorient it to RAS+.
+.. code-block:: bash
+
+    python scripts/m2m_download_template.py /path/to/allen_template_25um.nii --res 25 --apply-transform
+
 Docker
 ~~~~~~
 * Display the help for a script
 .. code-block:: bash
 
     docker run linumuqam/m2m m2m_compute_transform_matrix.py --help
+
+* Download an Allen mouse brain template at 25 micron, and reorient it to RAS+.
+.. code-block:: bash
+
+    docker run -v /path/to/local/data:/data linumuqam/m2m m2m_download_template.py /data/allen_template_25um.nii --res 25 --apply-transform
 
 * Compute the transform matrix ``transform_50micron.mat``, given a user-space reference volume ``reference.nii.gz`` in the folder ``/path/to/local/data``.
 .. code-block:: bash

--- a/m2m/version.py
+++ b/m2m/version.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
+2# -*- coding: utf-8 -*-
 
 import glob
 
 # Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
 _version_major = 0
 _version_minor = 1
-_version_micro = 1
+_version_micro = 2
 _version_extra = ''
 
 # Construct full version string from these.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 allensdk==0.16.3
-antspyx==0.3.3
+antspyx==0.3.*
 nibabel==4.0.2
 tqdm==4.64.1
 dipy==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ gdown==4.6.0
 ipython==7.34.0
 sphinx==5.3.0
 sphinx-argparse==0.4.0
+SimpleITK==2.2.1

--- a/scripts/m2m_download_template.py
+++ b/scripts/m2m_download_template.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Download the Allen mouse brain template, and setting the correct RAS+ direction and spacing.
+"""
+
+import argparse
+from allensdk.api.queries.reference_space_api import ReferenceSpaceApi
+from pathlib import Path
+import SimpleITK as sitk
+
+ALLEN_RESOLUTIONS = [10, 25, 50, 100]
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    p.add_argument("output",
+                   help="Output nifti filename")
+    p.add_argument("-r", "--resolution", default=100, type=int, choices=ALLEN_RESOLUTIONS,
+                   help="Template resolution in micron. Default=%(default)s")
+    p.add_argument("--apply_transform", action="store_true",
+                   help="Apply the transform to align the volume to RAS+ instead of relying only on the volume metadata")
+
+    return p
+
+
+def main():
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    # Prepare the output directory
+    output = Path(args.output)
+    extension = ""
+    if output.name.endswith(".nii"):
+        extension = ".nii"
+    elif output.name.endswith(".nii.gz"):
+        extension = ".nii.gz"
+    assert extension in [".nii", ".nii.gz"], "The output file must be a nifti file."
+    output.absolute()
+    output.parent.mkdir(exist_ok=True, parents=True)
+
+    # Preparing the filenames
+    nrrd_file = output.parent / f"allen_template_{args.resolution}.nrrd"
+
+    # Downloading the template
+    rpa = ReferenceSpaceApi(base_uri=str(output.parent))
+    rpa.download_template_volume(resolution=args.resolution, file_name=nrrd_file)
+
+    # Loading the nrrd file
+    vol = sitk.ReadImage(str(nrrd_file))
+
+    # Preparing the affine to align the template in the RAS+
+    r_mm = args.resolution / 1e3  # Convert the resolution from micron to mm
+    vol.SetSpacing([r_mm] * 3)  # Set the spacing in mm
+    if args.apply_transform:
+        vol = sitk.PermuteAxes(vol, (2, 0, 1))
+        vol = sitk.Flip(vol, (False, False, True))
+        vol.SetDirection([1, 0, 0, 0, 1, 0, 0, 0, 1])
+    else:
+        vol.SetDirection([0, 0, -1, 1, 0, 0, 0, -1, 0])  # Set the correct axes directions.
+    sitk.WriteImage(vol, str(output))
+    nrrd_file.unlink()  # Removes the nrrd file
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A new script was added to download the Allen mouse brain template from their SDK. The templates can be download at 4 resolutions (10, 25, 50, and 100 microns), and they can be reoritented to RAS+.