### PR TITLE
Create a function to import a single expriment given an injection coordinate issue #120

### DIFF
--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -7,6 +7,7 @@ Scripts
     scripts/m2m_compute_transform_matrix
     scripts/m2m_crossing_finder
     scripts/m2m_download_template
+    scripts/m2m_experiments_finder
     scripts/m2m_tract_filter
     scripts/m2m_import_proj_density
     scripts/m2m_import_tract

--- a/docs/scripts/m2m_experiments_finder.rst
+++ b/docs/scripts/m2m_experiments_finder.rst
@@ -1,0 +1,8 @@
+.. _script-m2m-experiments-finder:
+
+m2m_experiments_finder
+=====================
+.. argparse::
+   :filename: ../scripts/m2m_experiments_finder.py
+   :func: _build_arg_parser
+   :prog: m2m_experiments_finder.py

--- a/scripts/m2m_crossing_finder.py
+++ b/scripts/m2m_crossing_finder.py
@@ -5,7 +5,7 @@
     Find crossing regions (ROIs) between Allen Mouse Brain Connectivity
     experiments.
     Experiments are found by search in the Allen Mouse Brain Connectivity API
-    giving two or three MI-Brain voxel coordinates.\n
+    giving two or three User Data Space (UDS) voxel coordinates.\n
 
     - Generate projection density maps for each experiment.
       Maps are downloaded from the Allen Mouse Brain Connectivity API.\n
@@ -89,13 +89,13 @@ def _build_arg_parser():
     add_matrix_arg(p)
     add_reference_arg(p)
     p.add_argument('--red', nargs=3, type=int, required=True,
-                   help='MI-Brain voxels coordinates of first experiment.\n'
+                   help='UDS voxels coordinates of first experiment.\n'
                         'First experiment will be colored in red.')
     p.add_argument('--green', nargs=3, type=int, required=True,
-                   help='MI-Brain voxels coordinates of second experiment.\n'
+                   help='UDS voxels coordinates of second experiment.\n'
                         'Second experiment will be colored in green.')
     p.add_argument('--blue', nargs=3, type=int,
-                   help='MI-Brain voxels coordinates of third experiment.\n'
+                   help='UDS voxels coordinates of third experiment.\n'
                         'Third experiment will be colored in blue.')
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument('--injection', action="store_true",

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -167,8 +167,8 @@ def main():
                 exps_ids = allen_exps[0:args.nb_of_exps-1]['id']
             else:
                 exps_ids = allen_exps[0]['id']
-        else:
-            exps_ids = allen_exps[0]['id']
+    else:
+        exps_ids = allen_exps[0]['id']
 
     print("{} experiments founded, downloading...".format(exps_ids))
 

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -179,7 +179,7 @@ def main():
         method = "injected"
     if args.spatial:
         method = "with_high_signal"
-    subdir_ = f"experiments_{method}_at_[{args.x},{args.y},{args.z}]_at_{args.res}_microns"
+    subdir_ = f"experiments_{method}_at_{args.x}_{args.y}_{args.z}_at_{args.res}_microns"
     subdir = Path(args.dir / subdir_)
     subdir.mkdir(exist_ok=True, parents=True)
 
@@ -192,7 +192,7 @@ def main():
 
         # Projection density maps Niftis and Nrrd files
         nrrd_file = "{}_{}.nrrd".format(id, args.res)
-        nifti_file = "{}_{}_{}_proj_density_{}.nii.gz".format(id,
+        nifti_file = subdir / "{}_{}_{}_proj_density_{}.nii.gz".format(id,
                                                               roi, loc, args.res)
         check_file_exists(parser, args, nifti_file)
 

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -176,7 +176,7 @@ def main():
         writer = csv.writer(csv_file)
 
         # Write the header
-        writer.writerow(['ids'])
+        writer.writerow(['id'])
 
         # Write the data rows
         for id in exps_ids:

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -2,31 +2,29 @@
 # -*- coding: utf-8 -*-
 
 """
-    Find Allen Mouse Brain Connectivity (AMBCA) experiments.
+    Find experiments in the Allen Mouse Brain Connectivity Atlas (AMBCA)
+    dataset giving a set of User Data Space (UDS) voxel coordinates [x, y, z].\n
 
-    Experiments are searched in the AMBCA Dataset
-    giving a set of User Data Space (UDS) voxel coordinates [x, y, z].\n
+    The script then saves the experiment identifiers in a .csv file,
+    which can be used as input for the "m2m_import_proj_density.py" script.\n
 
     Important: Select the same resolution as your matrix
     We higly recommend to work with high resolution (starting from 50)
     in order to search experiments more precisely.\n
 
-    Examples:
-    ---------
-    Generate projection density maps for each experiment.\n
-    Maps are downloaded from the AMBCA API.\n
+    Example:
+    --------
+    1. Find experiments identifiers (a or b):
+        a. Injection coordinate search: (--injection)
+        >>> m2m_experiments_finder.py resolution path/to/.mat path/to/ref.nii.gz
+            x y z --injection --nb_of_exps n
 
-    All files are stored in a same folder.\n
+        b.Spatial search: (--spatial):
+        >>> m2m_experiments_finder.py resolution path/to/.mat path/to/ref.nii.gz
+            x y z --injection --nb_of_exps n
 
-    Injection coordinate search: (--injection)
-
-    >>> m2m_experiments_finder.py resolution path/to/.mat path/to/ref.nii.gz
-        x y z --injection --nb_of_exps n
-
-    Spatial search: (--spatial):
-
-    >>> m2m_experiments_finder.py resolution path/to/.mat path/to/ref.nii.gz
-        x y z --injection --nb_of_exps n
+    2. Call m2m_import_proj_density.py with theses indentifiers as an input:
+       (see m2m_import_proj_density.py documentation)
 """
 
 import argparse

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -169,6 +169,7 @@ def main():
                 exps_ids = allen_exps[0]['id']
     else:
         exps_ids = allen_exps[0]['id']
+    exps_ids = [exps_ids]
 
     print("{} experiments founded, downloading...".format(exps_ids))
 
@@ -178,7 +179,7 @@ def main():
         method = "injected"
     if args.spatial:
         method = "with_high_signal"
-    subdir_ = f"experiments_{method}_at_[{args.x},{args.y},{args.z}_at_{args.res}_microns]"
+    subdir_ = f"experiments_{method}_at_[{args.x},{args.y},{args.z}]_at_{args.res}_microns"
     subdir = Path(args.dir / subdir_)
     subdir.mkdir(exist_ok=True, parents=True)
 

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+    Find Allen Mouse Brain Connectivity (AMBCA) experiments.
+
+    Experiments are searched in the AMBCA Dataset
+    giving a set of User Data Space (UDS) voxel coordinates [x, y, z].\n
+
+    Important: Select the same resolution as your matrix
+    We higly recommend to work with high resolution (starting from 50)
+    in order to search experiments more precisely.\n
+
+    Examples:
+    ---------
+    Generate projection density maps for each experiment.\n
+    Maps are downloaded from the AMBCA API.\n
+
+    All files are stored in a same folder.\n
+
+    Injection coordinate search: (--injection)
+
+    >>> m2m_experiments_finder.py path/to/.mat path/to/ref.nii.gz
+        resolution x y z --injection --nb_of_exps n
+
+    Spatial search: (--spatial):
+
+    >>> m2m_experiments_finder.py path/to/.mat path/to/ref.nii.gz
+        resolution x y z --injection --nb_of_exps n
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from m2m.allensdk_utils import (download_proj_density_vol,
+                                get_injection_infos,
+                                get_mcc_exps,
+                                get_mcc_stree,
+                                search_experiments)
+from m2m.control import (add_cache_arg,
+                         add_output_dir_arg,
+                         add_overwrite_arg,
+                         add_resolution_arg,
+                         check_file_exists,
+                         add_matrix_arg,
+                         add_reference_arg,
+                         check_input_file)
+from m2m.transform import (pretransform_vol_PIR_UserDataSpace,
+                           registrate_allen2UserDataSpace,
+                           get_allen_coords)
+from m2m.util import (save_nifti,
+                      load_user_template)
+
+EPILOG = """
+Author : Mahdi
+"""
+
+
+def _build_arg_parser():
+    p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
+                                epilog=EPILOG, description=__doc__)
+    add_matrix_arg(p)
+    add_reference_arg(p)
+    p.add_argument('x', type=int, required=True,
+                   help='X-component of UDS voxel coordinates')
+    p.add_argument('y', type=int, required=True,
+                   help='Y-component of UDS voxel coordinates')
+    p.add_argument('z', type=int, required=True,
+                   help='Y-component of UDS voxel coordinates')
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument('--injection', action="store_true",
+                   help='Use `experiment_injection_coordinate_search` '
+                        'to find experiments.\n'
+                        'https://allensdk.readthedocs.io/en/latest/'
+                        'allensdk.api.queries.mouse_connectivity_api.html')
+    g.add_argument('--spatial', action="store_true",
+                   help='Use `experiment_spatial_search` '
+                        'to find experiments.\n'
+                        'https://allensdk.readthedocs.io/en/latest/'
+                        'allensdk.api.queries.mouse_connectivity_api.html')
+    p.add_argument('--nb_of_exps', type=int, default=1,
+                   help='Number of experiments needed. 1 by default.')
+    add_resolution_arg(p)
+    add_output_dir_arg(p)
+    add_cache_arg(p)
+    add_overwrite_arg(p)
+    return p
+
+
+def check_coords_in_bbox(parser, args):
+    """
+    Verify that the provided coordinates are within the reference
+    volume bounding box.
+
+    Parameters
+    ----------
+    parser: argparse.ArgumentParser object
+        Parser.
+    args: argparse namespace
+        Argument list.
+    """
+    # Load the reference
+    reference = load_user_template(args.reference)
+
+    # Verifying coords
+    x, y, z = range(0, reference.shape[0]), range(0, reference.shape[1]), range(0, reference.shape[2])
+    if args.x not in x or \
+            args.y not in y or \
+            args.z not in z:
+        parser.error('Invalid red coordinates'
+                     f'x, y, z values must be in {reference.shape} at {args.res} microns')
+
+
+def main():
+    # Building argparser
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    # Loading reference
+    check_input_file(parser, args.reference)
+    if not (args.reference).endswith(".nii") and \
+            not (args.reference).endswith(".nii.gz"):
+        parser.error("reference must be a nifti file.")
+    user_vol = load_user_template(args.reference)
+
+    # Checking that the coords are in the bounding box
+    check_coords_in_bbox(parser, args)
+
+    # Checking file mat
+    check_input_file(parser, args.file_mat)
+
+    # Getting experiments from Mouse Connectivity Cache
+    allen_experiments = get_mcc_exps(args.nocache)
+
+    # Configuring output directory
+    args.dir = Path(args.dir)
+    args.dir.mkdir(exist_ok=True, parents=True)
+
+    # Creating UDS vector coords
+    uds_coords = [args.x, args.y, args.z]
+
+    # Getting Allen coords
+    allen_coords = get_allen_coords(uds_coords, args.res,
+                                    args.file_mat, user_vol)
+    # Searching Allen experiments
+    allen_exps = search_experiments(args.injection, args.spatial,
+                                    allen_coords)
+
+    # Checking if allen_exps is not empty
+    if allen_exps.lenght == 0:
+        sys.exit("No experiment founded for [{},{},{}]".format(args.x, args.y, args.z))
+
+    # Checking if there are enough allen_exps compared to the nb_of_exps needed
+    if args.nb_of_exps > 1:
+        if allen_exps.length < args.nb_of_exps:
+            print("Only {} experiments founded at [{},{},{}],"
+                  "processing...".format(allen_exps.length, args.x, args.y, args.z))
+
+            # Resetting the number of experiments needed to the total number available
+            nb_of_exps = allen_exps.length
+
+            # Retrieving experiments ids
+            if nb_of_exps > 1:
+                exps_ids = allen_exps[0:args.nb_of_exps-1]['id']
+            else:
+                exps_ids = allen_exps[0]['id']
+        else:
+            exps_ids = allen_exps[0]['id']
+
+    print("{} experiments founded, downloading...".format(exps_ids))
+
+    # Preparing files names
+    # Creating subdir
+    if args.injection:
+        method = "injected"
+    if args.spatial:
+        method = "with_high_signal"
+    subdir_ = f"experiments_{method}_at_[{args.x},{args.y},{args.z}_at_{args.res}_microns]"
+    subdir = Path(args.dir / subdir_)
+    subdir.mkdir(exist_ok=True, parents=True)
+
+    # Iterating on each experiments
+    for id in exps_ids:
+
+        # Retrieving experiment information
+        roi = get_injection_infos(allen_experiments, id)[0]
+        loc = get_injection_infos(allen_experiments, id)[2]
+
+        # Projection density maps Niftis and Nrrd files
+        nrrd_file = "{}_{}.nrrd".format(id, args.res)
+        nifti_file = "{}_{}_{}_proj_density_{}.nii.gz".format(id,
+                                                              roi, loc, args.res)
+        check_file_exists(parser, args, nifti_file)
+
+        # Downloading projection density maps
+        exp_vol = download_proj_density_vol(nrrd_file, id,
+                                            args.res, args.nocache)
+
+        # Transforming manually to RAS+
+        exp_vol = pretransform_vol_PIR_UserDataSpace(exp_vol, user_vol)
+
+        # Converting Allen volumes to float32
+        exp_vol = exp_vol.astype(np.float32)
+
+        # Applying ANTsPyX registration
+        warped_vol = registrate_allen2UserDataSpace(args.file_mat,
+                                                    exp_vol, user_vol, allen_res=args.res)
+
+        # Saving Niftis files
+        save_nifti(warped_vol, user_vol.affine, nifti_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -150,17 +150,17 @@ def main():
                                     allen_coords)
 
     # Checking if allen_exps is not empty
-    if allen_exps.lenght == 0:
+    if len(allen_exps) == 0:
         sys.exit("No experiment founded for [{},{},{}]".format(args.x, args.y, args.z))
 
     # Checking if there are enough allen_exps compared to the nb_of_exps needed
     if args.nb_of_exps > 1:
-        if allen_exps.length < args.nb_of_exps:
+        if len(allen_exps) < args.nb_of_exps:
             print("Only {} experiments founded at [{},{},{}],"
-                  "processing...".format(allen_exps.length, args.x, args.y, args.z))
+                  "processing...".format(len(allen_exps), args.x, args.y, args.z))
 
             # Resetting the number of experiments needed to the total number available
-            nb_of_exps = allen_exps.length
+            nb_of_exps = len(allen_exps)
 
             # Retrieving experiments ids
             if nb_of_exps > 1:

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -64,11 +64,11 @@ def _build_arg_parser():
                                 epilog=EPILOG, description=__doc__)
     add_matrix_arg(p)
     add_reference_arg(p)
-    p.add_argument('x', type=int, required=True,
+    p.add_argument('x', type=int,
                    help='X-component of UDS voxel coordinates')
-    p.add_argument('y', type=int, required=True,
+    p.add_argument('y', type=int,
                    help='Y-component of UDS voxel coordinates')
-    p.add_argument('z', type=int, required=True,
+    p.add_argument('z', type=int,
                    help='Y-component of UDS voxel coordinates')
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument('--injection', action="store_true",

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -20,13 +20,13 @@
 
     Injection coordinate search: (--injection)
 
-    >>> m2m_experiments_finder.py path/to/.mat path/to/ref.nii.gz
-        resolution x y z --injection --nb_of_exps n
+    >>> m2m_experiments_finder.py resolution path/to/.mat path/to/ref.nii.gz
+        x y z --injection --nb_of_exps n
 
     Spatial search: (--spatial):
 
-    >>> m2m_experiments_finder.py path/to/.mat path/to/ref.nii.gz
-        resolution x y z --injection --nb_of_exps n
+    >>> m2m_experiments_finder.py resolution path/to/.mat path/to/ref.nii.gz
+        x y z --injection --nb_of_exps n
 """
 
 import argparse
@@ -62,6 +62,7 @@ Author : Mahdi
 def _build_arg_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=EPILOG, description=__doc__)
+    add_resolution_arg(p)
     add_matrix_arg(p)
     add_reference_arg(p)
     p.add_argument('x', type=int,
@@ -83,7 +84,6 @@ def _build_arg_parser():
                         'allensdk.api.queries.mouse_connectivity_api.html')
     p.add_argument('--nb_of_exps', type=int, default=1,
                    help='Number of experiments needed. 1 by default.')
-    add_resolution_arg(p)
     add_output_dir_arg(p)
     add_cache_arg(p)
     add_overwrite_arg(p)

--- a/scripts/m2m_experiments_finder.py
+++ b/scripts/m2m_experiments_finder.py
@@ -110,7 +110,7 @@ def check_coords_in_bbox(parser, args):
     if args.x not in x or \
             args.y not in y or \
             args.z not in z:
-        parser.error('Invalid red coordinates'
+        parser.error('Invalid coordinates '
                      f'x, y, z values must be in {reference.shape} at {args.res} microns')
 
 
@@ -156,7 +156,7 @@ def main():
     # Checking if there are enough allen_exps compared to the nb_of_exps needed
     if args.nb_of_exps > 1:
         if len(allen_exps) < args.nb_of_exps:
-            print("Only {} experiments founded at [{},{},{}],"
+            print("Only {} experiments founded at [{},{},{}], "
                   "processing...".format(len(allen_exps), args.x, args.y, args.z))
 
             # Resetting the number of experiments needed to the total number available
@@ -164,14 +164,15 @@ def main():
 
             # Retrieving experiments ids
             if nb_of_exps > 1:
-                exps_ids = allen_exps[0:args.nb_of_exps-1]['id']
+                exps_ids = [allen_exps[i]['id'] for i in range(0, nb_of_exps)]
             else:
-                exps_ids = allen_exps[0]['id']
+                exps_ids = [allen_exps[0]['id']]
+        else:
+            exps_ids = [allen_exps[i]['id'] for i in range(0, args.nb_of_exps)]
     else:
-        exps_ids = allen_exps[0]['id']
-    exps_ids = [exps_ids]
+        exps_ids = [allen_exps[0]['id']]
 
-    print("{} experiments founded, downloading...".format(exps_ids))
+    print("{} experiments founded, downloading...".format(len(exps_ids)))
 
     # Preparing files names
     # Creating subdir

--- a/scripts/m2m_import_proj_density.py
+++ b/scripts/m2m_import_proj_density.py
@@ -9,8 +9,13 @@
 
     Minimum mandatory requires to call the script : (a)
 
-    >>> m2m_import_proj_density.py id path/to/ref.nii.gz
+    >>> m2m_import_proj_density.py --id id path/to/ref.nii.gz
         path/to/matrix.mat resolution
+
+    OR if you have a CSV files containing ids (column labelled 'id')
+
+    >>> m2m_import_proj_density.py --ids_csv path/to/ids.csv 
+        path/to/ref.nii.gz path/to/matrix.mat resolution
     
     Find an id here : https://connectivity.brain-map.org/
 
@@ -47,6 +52,7 @@ import argparse
 import json
 from pathlib import Path
 import numpy as np
+import pandas as pd
 from m2m.control import (add_cache_arg,
                          add_matrix_arg,
                          add_output_dir_arg,
@@ -74,9 +80,13 @@ Author : Mahdi
 def _build_arg_parser():
     p = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                                 epilog=EPILOG, description=__doc__)
-    p.add_argument('id', type=int,
-                   help='Experiment id in the Allen Mouse Brain '
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument('--id', type=int,
+                   help='Single experiment id in the Allen Mouse Brain '
                         'Connectivity Atlas dataset.')
+    g.add_argument('--ids_csv', help='Path to a CSV file containing 1-n '
+                                     'experiment ids in the Allen Mouse '
+                                     'Brain Connectivity Atlas dataset.')
     add_reference_arg(p)
     add_matrix_arg(p)
     p.add_argument('--smooth', action="store_true",
@@ -124,28 +134,11 @@ def main():
     # Checking file mat
     check_input_file(parser, args.file_mat)
 
-    # Getting experiments from Cache
-    allen_experiments = get_mcc_exps(args.nocache)
-
-    # Verifying experiment id
-    ids = allen_experiments.id
-
-    if args.id not in ids:
-        parser.error("This experiment id : {}, doesn't exist. \n"
-                     "Please check : https://connectivity.brain-map.org/"
-                     .format(args.id))
-
     # Configuring output directory
     args.dir = Path(args.dir)
     args.dir.mkdir(exist_ok=True, parents=True)
 
-    # Experiment infos
-    # injection region, location, position (inj_coords_um)
-    roi = get_injection_infos(allen_experiments, args.id)[0]
-    loc = get_injection_infos(allen_experiments, args.id)[2]
-    pos = get_injection_infos(allen_experiments, args.id)[1]
-
-    # Configuring outputs filenames
+    # Checking the presence of flags files
     args_list = [args.map, args.roi, args.infos, args.bin]
 
     if not args.not_all and any(args_list):
@@ -165,109 +158,140 @@ def main():
                      "User --infos to download the experiment infos.\n"
                      "Use --bin to download the binarised map.")
 
-    file_map = args.dir / "{}_{}_{}_proj_density_{}.nii.gz"\
-                          .format(args.id, roi, loc, args.res)
-    if args.smooth:
-        file_map = args.dir / "{}_{}_{}_proj_density_{}_bSpline.nii.gz"\
-                              .format(args.id, roi, loc, args.res)
-    file_roi = args.dir / "{}_{}_{}_spherical_mask_{}.nii.gz"\
-                          .format(args.id, roi, loc, args.res)
-    file_infos = args.dir / "{}_{}_{}_inj_coords_{}.json"\
-                            .format(args.id, roi, loc, args.res)
-    file_bin = args.dir / "{}_{}_{}_proj_density_{}_bin{}.nii.gz"\
-                          .format(args.id, roi, loc, args.res, args.threshold)
+    # Retrieving Allen experiments
+    allen_experiments = get_mcc_exps(args.nocache)
+    
+    # Retrieving all experiments ids
+    ids = allen_experiments.id
 
-    file_list = [file_map, file_roi, file_infos, file_bin]
+    # Retrieving input ids
+    if args.id:
+        in_ids = [args.id]
+    if args.ids_csv:
+        in_ids = pd.read_csv(args.ids_csv).id.tolist()
+     
+    # Verifying experiment id
+    invalid_ids = [x for x in in_ids if x not in ids]
+    if invalid_ids:
+        invalid_ids_str = ', '.join(str(id) for id in invalid_ids)
+        parser.error("Experiment ID(s) {} do(es)n't exist.\n"
+                    "Please check: https://connectivity.brain-map.org/"
+                    .format(invalid_ids_str))
 
-    # Verifying if files exists
-    for file in file_list:
-        if args_list[file_list.index(file)] or not args.not_all:
-            check_file_exists(parser, args, file)
 
-    # Creating and Saving MI-brain injection coordinates coords in json file
-    # Saving experiments infos if --infos was used
-    if args.infos:
-        # Getting mi-brain voxel coordinates
-        # mib_coords = get_mib_coords(args, allen_experiments)
-        mib_coords = get_user_coords(pos, args.res, args.file_mat,
-                                     user_vol)
+    # Iterating on each id
+    for id in in_ids:
 
-        # Creating json content
-        dic = {"id": str(args.id), "roi": roi, "location": loc,
-               "allen_micron": str(pos), "mibrain_voxels": str(mib_coords)}
+        # Experiment infos
+        # injection region, location, position (inj_coords_um)
+        roi = get_injection_infos(allen_experiments, id)[0]
+        loc = get_injection_infos(allen_experiments, id)[2]
+        pos = get_injection_infos(allen_experiments, id)[1]
 
-        # Saving in json file
-        json_object = json.dumps(dic, indent=4)
-        with open(file_infos, "w") as outfile:
-            outfile.write(json_object)
-
-    # Downloading and Saving the projection density map if --map was used
-    if args.map or args.bin:
-        # Configuring files names
-        nrrd_file = "{}_{}.nrrd".format(args.id, args.res)
-
-        # Downloading projection density (API)
-        allen_vol = download_proj_density_vol(nrrd_file, args.id,
-                                              args.res, args.nocache)
-
-        # Transforming manually to RAS+
-        allen_vol = pretransform_vol_PIR_UserDataSpace(allen_vol, user_vol)
-
-        # Applying ANTsPyX registration
-        warped_vol = registrate_allen2UserDataSpace(
-            args.file_mat,
-            allen_vol,
-            user_vol,
-            allen_res=args.res,
-            smooth=args.smooth
-        )
-
-        # Deleting negatives values if bSpline method was used (--smooth)
+        # Configuring outputs filenames
+        file_map = args.dir / "{}_{}_{}_proj_density_{}.nii.gz"\
+                            .format(id, roi, loc, args.res)
         if args.smooth:
-            warped_vol[warped_vol < 0] = 0
+            file_map = args.dir / "{}_{}_{}_proj_density_{}_bSpline.nii.gz"\
+                                .format(id, roi, loc, args.res)
+        file_roi = args.dir / "{}_{}_{}_spherical_mask_{}.nii.gz"\
+                            .format(id, roi, loc, args.res)
+        file_infos = args.dir / "{}_{}_{}_inj_coords_{}.json"\
+                                .format(id, roi, loc, args.res)
+        file_bin = args.dir / "{}_{}_{}_proj_density_{}_bin{}.nii.gz"\
+                            .format(id, roi, loc, args.res, args.threshold)
 
-        if args.map:
-            # Creating and Saving the Nifti map
-            save_nifti(warped_vol, user_vol.affine, file_map)
+        file_list = [file_map, file_roi, file_infos, file_bin]
 
-        if args.bin:
-            # Creating and Saving the Nifti bin map
-            bin_vol = (warped_vol >= args.threshold).astype(np.int32)
-            save_nifti(bin_vol, user_vol.affine, file_bin)
+        # Verifying if files exists
+        for file in file_list:
+            if args_list[file_list.index(file)] or not args.not_all:
+                check_file_exists(parser, args, file)
 
-    # Creating and Saving the spherical mask if --roi was used
-    if args.roi:
-        # Converting the coordinates in voxels depending the resolution
-        inj_coord_voxels = (pos[0]/args.res,
-                            pos[1]/args.res,
-                            pos[2]/args.res)
+        # Creating and Saving MI-brain injection coordinates coords in json file
+        # Saving experiments infos if --infos was used
+        if args.infos:
+            # Getting mi-brain voxel coordinates
+            # mib_coords = get_mib_coords(args, allen_experiments)
+            mib_coords = get_user_coords(pos, args.res, args.file_mat,
+                                         user_vol)
 
-        # Configuring the bounding box
-        bbox_allen = select_allen_bbox(args.res)
+            # Creating json content
+            dic = {"id": str(id), "roi": roi, "location": loc,
+                "allen_micron": str(pos), "mibrain_voxels": str(mib_coords)}
 
-        # Drawing the spherical mask
-        roi_sphere_allen = draw_spherical_mask(
-            shape=bbox_allen,
-            center=inj_coord_voxels,
-            radius=400//args.res)
+            # Saving in json file
+            json_object = json.dumps(dic, indent=4)
+            with open(file_infos, "w") as outfile:
+                outfile.write(json_object)
 
-        # Transforming manually to RAS+
-        roi_sphere_allen = pretransform_vol_PIR_UserDataSpace(roi_sphere_allen,
-                                                              user_vol)
+        # Downloading and Saving the projection density map if --map was used
+        if args.map or args.bin:
+            # Configuring files names
+            nrrd_file = "{}_{}.nrrd".format(id, args.res)
 
-        # Applying ANTsPyX registration
-        roi_sphere_avgt = registrate_allen2UserDataSpace(
-            args.file_mat,
-            roi_sphere_allen,
-            user_vol,
-            allen_res=args.res,
-        )
+            # Downloading projection density (API)
+            allen_vol = download_proj_density_vol(nrrd_file, id,
+                                                  args.res, args.nocache)
 
-        # Deleting non needed interpolated values
-        roi_sphere_avgt = roi_sphere_avgt.astype(np.int32)
+            # Transforming manually to RAS+
+            allen_vol = pretransform_vol_PIR_UserDataSpace(allen_vol, user_vol)
 
-        # Creating and Saving the Nifti spherical mask
-        save_nifti(roi_sphere_avgt, user_vol.affine, file_roi)
+            # Applying ANTsPyX registration
+            warped_vol = registrate_allen2UserDataSpace(
+                args.file_mat,
+                allen_vol,
+                user_vol,
+                allen_res=args.res,
+                smooth=args.smooth
+            )
+
+            # Deleting negatives values if bSpline method was used (--smooth)
+            if args.smooth:
+                warped_vol[warped_vol < 0] = 0
+
+            if args.map:
+                # Creating and Saving the Nifti map
+                save_nifti(warped_vol, user_vol.affine, file_map)
+
+            if args.bin:
+                # Creating and Saving the Nifti bin map
+                bin_vol = (warped_vol >= args.threshold).astype(np.int32)
+                save_nifti(bin_vol, user_vol.affine, file_bin)
+
+        # Creating and Saving the spherical mask if --roi was used
+        if args.roi:
+            # Converting the coordinates in voxels depending the resolution
+            inj_coord_voxels = (pos[0]/args.res,
+                                pos[1]/args.res,
+                                pos[2]/args.res)
+
+            # Configuring the bounding box
+            bbox_allen = select_allen_bbox(args.res)
+
+            # Drawing the spherical mask
+            roi_sphere_allen = draw_spherical_mask(
+                shape=bbox_allen,
+                center=inj_coord_voxels,
+                radius=400//args.res)
+
+            # Transforming manually to RAS+
+            roi_sphere_allen = pretransform_vol_PIR_UserDataSpace(roi_sphere_allen,
+                                                                user_vol)
+
+            # Applying ANTsPyX registration
+            roi_sphere_avgt = registrate_allen2UserDataSpace(
+                args.file_mat,
+                roi_sphere_allen,
+                user_vol,
+                allen_res=args.res,
+            )
+
+            # Deleting non needed interpolated values
+            roi_sphere_avgt = roi_sphere_avgt.astype(np.int32)
+
+            # Creating and Saving the Nifti spherical mask
+            save_nifti(roi_sphere_avgt, user_vol.affine, file_roi)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Why this pull request ?**
New script needed : allow a user to import allen experiments given an 3D-voxel coordinate in his data space

**What's in this pull request ?**
- `m2m_experiments_finder.py` : the new scriptconcerned by this issue
- its sphinx documentation .rst
- a quick changed in the documentation of `m2m_crossing_finder.py` to replace MI-BRAIN by UDS

**What does the script do ?**
- it searches a given number (---nb_of_exps) of projection density maps like `m2m_import_proj_density.py` given a 3D-voxel coordinate in UDS (x y  z) either by injection or spatial search (--injection, --spatial). 
- Downloads them
- Aligns them to the UDS
- Saves them in a folder named depending of the research method, the coordinates given and the resolution
- Names each projection map according to the `m2m_import_proj_density.py` standard.

**Discussion**
The fact that this script import the projection maps seems rendondant. What about returning only the ids of experiments rather that downloading them? Because `m2m_import_proj_density.py` can already do the importation and have many usefull options.